### PR TITLE
Fix parseWaitTime empty input handling

### DIFF
--- a/utils/parseWaitTime.test.ts
+++ b/utils/parseWaitTime.test.ts
@@ -16,3 +16,8 @@ test("エラー は null にパースされる", () => {
   const result = parseWaitTime("エラー");
   expect(result).toBe(null);
 });
+
+test("空文字は null にパースされる", () => {
+  const result = parseWaitTime("");
+  expect(result).toBe(null);
+});

--- a/utils/parseWaitTime.ts
+++ b/utils/parseWaitTime.ts
@@ -1,6 +1,6 @@
 export const parseWaitTime = (waitTime: string): number | null => {
   const m = waitTime.match(/^(\d+時間)?\s*(\d+分)?(?:以下)?$/);
-  if (!m) return null;
+  if (!m || (!m[1] && !m[2])) return null;
 
   const hours = m[1] ? Number(m[1].replace("時間", "")) : 0;
   const minutes = m[2] ? Number(m[2].replace("分", "")) : 0;


### PR DESCRIPTION
## Summary
- return null when parseWaitTime receives an empty string
- cover empty string in unit tests

## Testing
- `pnpm run test` *(fails: watch mode requires manual exit)*

------
https://chatgpt.com/codex/tasks/task_e_685af26bdc648322a306e8538b627f10